### PR TITLE
External resource delivery page

### DIFF
--- a/lndr.routing.yml
+++ b/lndr.routing.yml
@@ -50,3 +50,6 @@ lndr.example_service:
     _controller: '\Drupal\lndr\Controller\LndrExampleController::service'
   requirements:
     _permission: 'access content'
+
+route_callbacks:
+  - '\Drupal\lndr\Routing\LndrRoutes::routes'

--- a/lndr.services.yml
+++ b/lndr.services.yml
@@ -1,4 +1,11 @@
 services:
+
+  path_processor.lndr:
+    class: Drupal\lndr\PathProcessor\LndrPathProcessor
+    arguments: ['@stream_wrapper_manager']
+    tags:
+    - { name: path_processor_inbound, priority: 200 }
+
   lndr_event_subscriber:
     class: Drupal\lndr\EventSubscriber\LndrResponseEventSubscriber
     arguments: ['@config.factory', '@path.alias_manager', '@path.matcher']


### PR DESCRIPTION
Changed implementation:

- Replacing Lndr URLs (lndr.co/p/) to the "current" domain.
- Delivery page has been created.
Delivery page works same as image styles. If a file does not exist on site, we will send a request to Lndr and try to download it.

Unsolved issues:
Add this configuration line to your setttings.php file
`$config['system.performance']['fast_404']['exclude_paths'] = '/\/(?:styles)|(?:lndr)|(?:system\/files)\//';
`
